### PR TITLE
fix: CIP-64 are sent as EIP-1559 transactions

### DIFF
--- a/src/chains/celo/sendTransaction.test.ts
+++ b/src/chains/celo/sendTransaction.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test, vi } from 'vitest'
+import {
+  createTransport,
+  type EIP1193RequestFn,
+  createWalletClient,
+  type WalletRpcSchema,
+  type PublicRpcSchema,
+} from '../../index.js'
+import type { CeloTransactionSerialized } from './types.js'
+import { celo } from '../index.js'
+import { generateRandomAddress } from './utils.js'
+import { privateKeyToAccount } from '~viem/accounts/privateKeyToAccount.js'
+import { accounts } from '~test/src/constants.js'
+import { parseTransactionCelo } from './parsers.js'
+
+describe('sendTransaction', () => {
+  test('provides valid transaction params to sign for eth_sendRawTransaction (local account)', async () => {
+    let rawTransaction: CeloTransactionSerialized | undefined
+
+    const feeCurrencyAddress = generateRandomAddress()
+    const transactionHash = generateRandomAddress()
+    const toAddress = generateRandomAddress()
+
+    const mockTransport = () =>
+      createTransport({
+        key: 'mock',
+        name: 'Mock Transport',
+        request: vi.fn(async (request) => {
+          if (request.method === 'eth_chainId') {
+            return celo.id
+          }
+
+          if (request.method === 'eth_getBlockByNumber') {
+            // We just need baseFeePerGas for gas estimation
+            return {
+              baseFeePerGas: '0x12a05f200',
+            }
+          }
+
+          if (request.method === 'eth_estimateGas') {
+            return 1n
+          }
+
+          if (request.method === 'eth_getTransactionCount') {
+            return 0
+          }
+
+          if (request.method === 'eth_sendRawTransaction') {
+            rawTransaction = (
+              request.params as Array<CeloTransactionSerialized>
+            )[0]
+
+            return transactionHash
+          }
+
+          return null
+        }) as EIP1193RequestFn<WalletRpcSchema & PublicRpcSchema>,
+        type: 'mock',
+      })
+    const client = createWalletClient({
+      transport: mockTransport,
+      chain: celo,
+      // We need a local account
+      account: privateKeyToAccount(accounts[0].privateKey),
+    })
+
+    const hash = await client.sendTransaction({
+      value: 1n,
+      to: toAddress,
+      feeCurrency: feeCurrencyAddress,
+      maxFeePerGas: 123n,
+      maxPriorityFeePerGas: 123n,
+    })
+
+    expect(hash).toEqual(transactionHash)
+    expect(rawTransaction).not.toBeUndefined()
+
+    if (rawTransaction) {
+      expect(parseTransactionCelo(rawTransaction).type).toEqual('cip64')
+    }
+  })
+})

--- a/src/chains/celo/serializers.test.ts
+++ b/src/chains/celo/serializers.test.ts
@@ -130,21 +130,6 @@ describe('cip42', () => {
     )
   })
 
-  test('args: gatewayFee (absent)', () => {
-    const transaction: TransactionSerializableCIP42 = {
-      ...baseCip42,
-      gatewayFeeRecipient: undefined,
-      gatewayFee: undefined,
-      type: 'cip42',
-    }
-    expect(parseTransactionCelo(serializeTransactionCelo(transaction))).toEqual(
-      {
-        ...transaction,
-        type: 'cip42',
-      },
-    )
-  })
-
   test('args: maxFeePerGas (absent)', () => {
     const transaction: TransactionSerializableCIP42 = {
       ...baseCip42,
@@ -474,6 +459,21 @@ describe('cip64', () => {
     ).toEqual(tx2)
     expect(parseTransactionCelo(tx1)).toEqual(parseTransactionCelo(tx2))
     expect(parseTransactionCelo(tx1)).toEqual({ ...baseCip64, type: 'cip64' })
+  })
+
+  test('CIP-42 transaction that has all CIP-64 fields and CIP-64 takes precedence', () => {
+    const transaction: TransactionSerializableCIP42 = {
+      ...baseCip42,
+      gatewayFeeRecipient: undefined,
+      gatewayFee: undefined,
+      type: 'cip42',
+    }
+    expect(parseTransactionCelo(serializeTransactionCelo(transaction))).toEqual(
+      {
+        ...transaction,
+        type: 'cip64',
+      },
+    )
   })
 })
 

--- a/src/chains/celo/serializers.ts
+++ b/src/chains/celo/serializers.ts
@@ -231,7 +231,7 @@ export function assertTransactionCIP64(
   )
     throw new TipAboveFeeCapError({ maxFeePerGas, maxPriorityFeePerGas })
 
-  if (isPresent(feeCurrency) && !feeCurrency?.startsWith('0x')) {
+  if (isPresent(feeCurrency) && !isAddress(feeCurrency)) {
     throw new BaseError(
       '`feeCurrency` MUST be a token address for CIP-64 transactions.',
     )

--- a/src/chains/celo/utils.test.ts
+++ b/src/chains/celo/utils.test.ts
@@ -74,7 +74,7 @@ describe('isPresent', () => {
 })
 
 describe('isEIP1559', () => {
-  test('it checks if a transaction is EIP-1159', () => {
+  test('it checks if a transaction is EIP-1559', () => {
     expect(isEIP1559({})).toBe(false)
 
     expect(
@@ -118,7 +118,7 @@ describe('isEIP1559', () => {
 })
 
 describe('isCIP42', () => {
-  test('it allows forcing the type even if transaction is not EIP-1159', () => {
+  test('it allows forcing the type even if transaction is not EIP-1559', () => {
     expect(
       isCIP42({
         type: 'cip42',
@@ -203,7 +203,7 @@ describe('isCIP42', () => {
 })
 
 describe('isCIP64', () => {
-  test('it allows forcing the type even if transaction is not EIP-1159', () => {
+  test('it allows forcing the type even if transaction is not EIP-1559', () => {
     expect(
       isCIP64({
         type: 'cip64',

--- a/src/chains/celo/utils.test.ts
+++ b/src/chains/celo/utils.test.ts
@@ -236,6 +236,30 @@ describe('isCIP64', () => {
     ).toBe(true)
   })
 
+  test('it recognizes valid CIP-64 with "eip1559" type provided', () => {
+    expect(
+      isCIP64({
+        type: 'eip1559',
+        feeCurrency: mockAddress,
+        gatewayFeeRecipient: '0x',
+        gatewayFee: 0n,
+        maxFeePerGas: 123n,
+        maxPriorityFeePerGas: 456n,
+        from: mockAddress,
+      }),
+    ).toBe(true)
+
+    expect(
+      isCIP64({
+        type: 'eip1559',
+        feeCurrency: mockAddress,
+        maxFeePerGas: 123n,
+        maxPriorityFeePerGas: 456n,
+        from: mockAddress,
+      }),
+    ).toBe(true)
+  })
+
   test('it does not recognize valid CIP-64', () => {
     expect(isCIP64({})).toBe(false)
 

--- a/src/chains/celo/utils.ts
+++ b/src/chains/celo/utils.ts
@@ -1,4 +1,5 @@
 import type { Address } from 'abitype'
+import { randomBytes } from 'crypto'
 import { trim } from '../../utils/data/trim.js'
 import type {
   CeloTransactionRequest,
@@ -69,4 +70,8 @@ export function isCIP64(
     isEmpty(transaction.gatewayFee) &&
     isEmpty(transaction.gatewayFeeRecipient)
   )
+}
+
+export function generateRandomAddress(): Address {
+  return `0x${randomBytes(20).toString('hex')}` as Address
 }

--- a/src/chains/celo/utils.ts
+++ b/src/chains/celo/utils.ts
@@ -1,5 +1,4 @@
 import type { Address } from 'abitype'
-import { randomBytes } from 'crypto'
 import { trim } from '../../utils/data/trim.js'
 import type {
   CeloTransactionRequest,
@@ -70,8 +69,4 @@ export function isCIP64(
     isEmpty(transaction.gatewayFee) &&
     isEmpty(transaction.gatewayFeeRecipient)
   )
-}
-
-export function generateRandomAddress(): Address {
-  return `0x${randomBytes(20).toString('hex')}` as Address
 }

--- a/src/chains/celo/utils.ts
+++ b/src/chains/celo/utils.ts
@@ -58,7 +58,16 @@ export function isCIP42(
 export function isCIP64(
   transaction: CeloTransactionSerializable | CeloTransactionRequest,
 ): transaction is TransactionSerializableCIP64 {
-  // Enable end-user to force the tx to be considered as a cip64
+  /*
+   * Enable end user to force the tx to be considered as a CIP-64.
+   *
+   * The preliminary type will be determined as "eip1559" by src/utils/transaction/getTransactionType.ts
+   * and so we need the logic below to check for the specific value instead of checking if just any
+   * transaction type is provided. If that's anything else than "cip64" then we need to reevaluate the
+   * type based on the transaction fields.
+   *
+   * Modify with caution and according to https://github.com/celo-org/celo-proposals/blob/master/CIPs/cip-0064.md
+   */
   if (transaction.type === 'cip64') {
     return true
   }

--- a/src/chains/celo/utils.ts
+++ b/src/chains/celo/utils.ts
@@ -43,7 +43,9 @@ export function isCIP42(
   transaction: CeloTransactionSerializable | CeloTransactionRequest,
 ): transaction is TransactionSerializableCIP42 {
   // Enable end-user to force the tx to be considered as a cip42
-  if (transaction.type) return transaction.type === 'cip42'
+  if (transaction.type === 'cip42') {
+    return true
+  }
 
   return (
     isEIP1559(transaction) &&
@@ -57,7 +59,9 @@ export function isCIP64(
   transaction: CeloTransactionSerializable | CeloTransactionRequest,
 ): transaction is TransactionSerializableCIP64 {
   // Enable end-user to force the tx to be considered as a cip64
-  if (transaction.type) return transaction.type === 'cip64'
+  if (transaction.type === 'cip64') {
+    return true
+  }
 
   return (
     isEIP1559(transaction) &&


### PR DESCRIPTION
This PR fixes bug where CIP-64 transactions are sent as EIP-1559 transactions.

It reverts code changes to `src/chains/celo/utils.ts` from [this commit](https://github.com/wagmi-dev/viem/commit/494dc538129e49fa8fa01b7e6d073605b0f00bde) and repurposes a test that started failing because of the change.

# Context

When `prepareTransactionRequest` [is called](https://github.com/wagmi-dev/viem/blob/main/src/actions/wallet/sendTransaction.ts#L167) and type is not explicitly provided then it [will be determined](https://github.com/wagmi-dev/viem/blob/main/src/actions/wallet/prepareTransactionRequest.ts#L148) by `getTransactionType` and because for CIP-64 all EIP-1559 fields are provided it will be set to `eip1559` as per:

```typescript
if (
    typeof transaction.maxFeePerGas !== 'undefined' ||
    typeof transaction.maxPriorityFeePerGas !== 'undefined'
  )
    return 'eip1559' as GetTransactionType<TTransactionSerializable>
```

[Previously the logic of "forcing" the type](https://github.com/wagmi-dev/viem/commit/c0da695a76225c7f24ca263f9109e34d8cd93dba#diff-f51139e09908a7b2fef2022c35f6c86577299a5db761fcc5db4d8cc8c10561dfR62) in `src/chains/celo/utils.ts` allowed it only if the type was explicitly set to `cip64` and otherwise it would try to determine if it's a CIP-64 transaction based on the provided fields:

```typescript
return (
    isEIP1559(transaction) &&
    isPresent(transaction.feeCurrency) &&
    isEmpty(transaction.gatewayFee) &&
    isEmpty(transaction.gatewayFeeRecipient)
)
```

After the aforementioned commit it won't ever get to determine the type based on the fields as it will always go into `if (transaction.type)` branch as the `eip1559` type is injected hence resulting in sending wrong transaction type to the blockchain.